### PR TITLE
Added a simple interval configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ ECMAScript 6 (JavaScript) NPM module for executing scheduled tasks
 npm i datetime-scheduler --save
 ```
 
-**Notice:** This module has zero NPM dependencies, but it uses ES6 language.
+**Notice:** This module has zero NPM dependencies, but it uses 
 
 ### Usage
-This example calls *asyncTask* method every saturday and sunday at 12:15 (and 30.500 seconds)
 ``` javascript
 const {createScheduler} = require('datetime-scheduler');
 
@@ -42,13 +41,7 @@ const options = {
 createScheduler("weekend at 12:15:30.500", configuration, options);
 ```
 
-In case you need only one execution on a specific day
-``` javascript
-const specificDay = "2019-05-18T19:30:00.000Z";
-const configuration = {
-    "timestamp": new Date(specificDay).getTime()
-};
-```
+You also can use a timestamp or an interval as your configuration options. 
 
 
 Check [weekend.js](https://github.com/lubino/datetime-scheduler/blob/master/example/weekend.js) for a working example.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ECMAScript 6 (JavaScript) NPM module for executing scheduled tasks
 npm i datetime-scheduler --save
 ```
 
-**Notice:** This module has zero NPM dependencies, but it uses 
+**Notice:** This module has zero NPM dependencies, but it uses ES6 language.
 
 ### Usage
 ``` javascript

--- a/scheduler.js
+++ b/scheduler.js
@@ -10,7 +10,7 @@ const DAYS = {
 const {sunday, monday, tuesday, wednesday, thursday, friday, saturday} = DAYS;
 const KEYS = Object.keys(DAYS);
 const minuteMillis = 60000;
-const minimalTimeout = 60 * minuteMillis;
+const minimalTimeout = 30 * minuteMillis;
 const active = [];
 let debug = message => console.log(`scheduler: ${message}`);
 
@@ -29,7 +29,11 @@ async function execute(name, options) {
 const millisFrom = (days, hours, minutes, seconds, millis) => (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000 + millis;
 
 function millisToNext(now, configuration) {
-    const {days, time, timestamp} = configuration;
+    const {days, time, timestamp, interval} = configuration;
+    if (interval) {
+        const timespan = interval * minuteMillis;
+        return timespan;
+    }
     if (timestamp) {
         const timeout = timestamp - now.getTime();
         if (timeout >= 0) return timeout;
@@ -116,7 +120,6 @@ function handleTimer(creatingNew) {
             }, timeout);
         }
     }
-
 }
 
 function minutesToDaysHoursMinutesArr(inMillis) {


### PR DESCRIPTION
Example of config option:
{ interval: 30 }
Minimal timeout was reduced to 30 minutes.